### PR TITLE
Import fix

### DIFF
--- a/mdx_linkify/__init__.py
+++ b/mdx_linkify/__init__.py
@@ -1,1 +1,1 @@
-from mdx_linkify import makeExtension
+from mdx_linkify.mdx_linkify import makeExtension


### PR DESCRIPTION
Using [Python-Markdown](https://github.com/waylan/Python-Markdown) 2.4 on a virtual environment of Python 3.3.3

Error message caused by vanilla linkify:

``` python
>>> import markdown
>>> markdown.markdown('http://example.org/', ['linkify'])
Traceback (most recent call last):
  File "C:\Users\DAS\testenv\lib\site-packages\markdown\__init__.py", line 197, in build_extension
    module = __import__(module_name, {}, {}, [module_name.rpartition('.')[0]])
ImportError: No module named 'markdown.extensions.linkify'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\DAS\testenv\lib\site-packages\markdown\__init__.py", line 410, in markdown
    md = Markdown(*args, **kwargs)
  File "C:\Users\DAS\testenv\lib\site-packages\markdown\__init__.py", line 137, in __init__
    configs=kwargs.get('extension_configs', {}))
  File "C:\Users\DAS\testenv\lib\site-packages\markdown\__init__.py", line 163, in registerExtensions
    ext = self.build_extension(ext, configs.get(ext, []))
  File "C:\Users\DAS\testenv\lib\site-packages\markdown\__init__.py", line 201, in build_extension
    module = __import__(module_name_old_style)
  File "C:\Users\DAS\testenv\lib\site-packages\mdx_linkify\__init__.py", line 1, in <module>
    from mdx_linkify import makeExtension
ImportError: cannot import name makeExtension
```

After uninstalling vanilla linkify and installing my changes, it works fine!
Hope this helps somebody.
