### PR TITLE
Make compatible with Bleach v2.0

### DIFF
--- a/mdx_linkify/mdx_linkify.py
+++ b/mdx_linkify/mdx_linkify.py
@@ -1,14 +1,7 @@
 import bleach
 
-from html5lib.sanitizer import HTMLSanitizer
-
 from markdown.postprocessors import Postprocessor
 from markdown import Extension
-
-
-class MyTokenizer(HTMLSanitizer):
-    def sanitize_token(self, token):
-        return token
 
 
 class LinkifyPostprocessor(Postprocessor):
@@ -18,8 +11,7 @@ class LinkifyPostprocessor(Postprocessor):
 
     def run(self, text):
         text = bleach.linkify(text,
-                              callbacks=self._callbacks,
-                              tokenizer=MyTokenizer)
+                              callbacks=self._callbacks)
         return text
 
 

--- a/mdx_linkify/tests.py
+++ b/mdx_linkify/tests.py
@@ -9,31 +9,31 @@ from mdx_linkify.mdx_linkify import LinkifyExtension
 class LinkifyTest(unittest.TestCase):
     def test_link(self):
         expected = '<p><a href="http://example.com">http://example.com</a></p>'
-        actual = markdown("http://example.com", extensions=["linkify"])
+        actual = markdown("http://example.com", extensions=["mdx_linkify"])
         self.assertEqual(expected, actual)
 
     def test_https_link(self):
         link = "https://example.com"
         expected = '<p><a href="{link}">{link}</a></p>'.format(link=link)
-        actual = markdown(link, extensions=["linkify"])
+        actual = markdown(link, extensions=["mdx_linkify"])
         self.assertEqual(expected, actual)
 
     def test_complex_link(self):
         link = "http://spam.cheese.bacon.eggs.io/?monty=Python#im_loving_it"
         expected = '<p><a href="{link}">{link}</a></p>'.format(link=link)
-        actual = markdown(link, extensions=["linkify"])
+        actual = markdown(link, extensions=["mdx_linkify"])
         self.assertEqual(expected, actual)
 
     def test_no_link(self):
         expected = '<p>foo.bar</p>'
-        actual = markdown("foo.bar", extensions=["linkify"])
+        actual = markdown("foo.bar", extensions=["mdx_linkify"])
         self.assertEqual(expected, actual)
 
     def test_links(self):
         expected = ('<p><a href="http://example.com">http://example.com</a> '
                     '<a href="http://example.org">http://example.org</a></p>')
         actual = markdown("http://example.com http://example.org",
-                          extensions=["linkify"])
+                          extensions=["mdx_linkify"])
         self.assertEqual(expected, actual)
 
     def test_links_with_text_between(self):
@@ -41,13 +41,13 @@ class LinkifyTest(unittest.TestCase):
                     'foo <a href="http://example.org">http://example.org'
                     '</a></p>')
         actual = markdown("http://example.com foo http://example.org",
-                          extensions=["linkify"])
+                          extensions=["mdx_linkify"])
         self.assertEqual(expected, actual)
 
     def test_existing_link(self):
         expected = '<p><a href="http://example.com">http://example.com</a></p>'
         actual = markdown("[http://example.com](http://example.com)",
-                          extensions=["linkify"])
+                          extensions=["mdx_linkify"])
         self.assertEqual(expected, actual)
 
     def test_image_that_has_link_in_it(self):
@@ -55,13 +55,13 @@ class LinkifyTest(unittest.TestCase):
         alt = "Monty"
 
         # Order is not guaranteed so we check for substring existence.
-        actual = markdown("![Monty]({})".format(src), extensions=["linkify"])
+        actual = markdown("![Monty]({})".format(src), extensions=["mdx_linkify"])
         self.assertIn(src, actual)
         self.assertIn(alt, actual)
 
     def test_no_escape(self):
         expected = '<script>alert(1)</script>'
-        actual = markdown(expected, extensions=["linkify"])
+        actual = markdown(expected, extensions=["mdx_linkify"])
         self.assertEqual(expected, actual)
 
     def test_callbacks(self):


### PR DESCRIPTION
- Adapt to change in [`bleach.linkify`](http://bleach.readthedocs.io/en/latest/linkify.html#bleach.linkify) API.
- Fix [“Shortened” Extension Names Deprecated](https://pythonhosted.org/Markdown/release-2.6.html#shortened-extension-names-deprecated) 