### PR TITLE
don't linkify URLs in backticks

### DIFF
--- a/mdx_linkify/mdx_linkify.py
+++ b/mdx_linkify/mdx_linkify.py
@@ -11,7 +11,8 @@ class LinkifyPostprocessor(Postprocessor):
 
     def run(self, text):
         text = bleach.linkify(text,
-                              callbacks=self._callbacks)
+                              callbacks=self._callbacks,
+                              skip_tags=['code'])
         return text
 
 

--- a/mdx_linkify/tests.py
+++ b/mdx_linkify/tests.py
@@ -50,6 +50,12 @@ class LinkifyTest(unittest.TestCase):
                           extensions=["mdx_linkify"])
         self.assertEqual(expected, actual)
 
+    def test_backticks_link(self):
+        expected = '<p><code>example.com</code></p>'
+        actual = markdown("`example.com`",
+                          extensions=["mdx_linkify"])
+        self.assertEqual(expected, actual)
+
     def test_image_that_has_link_in_it(self):
         src = "http://example.com/monty.jpg"
         alt = "Monty"


### PR DESCRIPTION
Fixes issue #6 

Tests:
```console
$ python3 tests.py 
...........
----------------------------------------------------------------------
Ran 11 tests in 0.143s

OK
```

Example before:
```python
>>> markdown('`example.com`', extensions=["mdx_linkify"])
'<p><code><a href="http://example.com">example.com</a></code></p>'
```
Example after:
```python
>>> markdown('`example.com`', extensions=["mdx_linkify"])
'<p><code>example.com</code></p>'
```