### PR TITLE
Change .add to .register to remove deprecation warnings

### DIFF
--- a/mdx_linkify/mdx_linkify.py
+++ b/mdx_linkify/mdx_linkify.py
@@ -19,11 +19,11 @@ class LinkifyPostprocessor(Postprocessor):
 class LinkifyExtension(Extension):
     config = {'linkify_callbacks': [[], 'Callbacks to send to bleach.linkify']}
 
-    def extendMarkdown(self, md, md_globals):
-        md.postprocessors.add(
-            "linkify",
+    def extendMarkdown(self, md):
+        md.postprocessors.register(
             LinkifyPostprocessor(md, self.getConfig('linkify_callbacks')),
-            "_begin")
+            "linkify",
+            50)
 
 
 def makeExtension(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(name="mdx_linkify",
           "Development Status :: 4 - Beta",
           "License :: OSI Approved :: MIT License",
       ],
-      install_requires=["Markdown>=2.6", "bleach>=2.0.0"],
+      install_requires=["Markdown>=3.0", "bleach>=2.0.0"],
       test_suite="mdx_linkify.tests")


### PR DESCRIPTION
Fixes #9 

see https://github.com/Python-Markdown/markdown/issues/719 for an explanation of priority vs. location string