### PR TITLE
Add linkify_parse_email option (and some fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,25 +30,20 @@ markdown("minimal http://example.org/", extensions=["mdx_linkify"])
 It's possible to omit links that match your custom filter with linkify
 callbacks.
 
-For example, to omit links that end with `.txt` extension:
+For example, to omit links that end with `.net` extension:
 
 ```python
 from mdx_linkify.mdx_linkify import LinkifyExtension
 from markdown import Markdown
 
-def dont_linkify_txt_extension(attrs, new=False):
-    if attrs["_text"].endswith(".txt"):
+def dont_linkify_net_extension(attrs, new=False):
+    if attrs["_text"].endswith(".net"):
         return None
 
     return attrs
 
 md = Markdown(
-    extensions=[LinkifyExtension()],
-    extension_configs={
-        "linkify": {
-            "linkify_callbacks": [[dont_linkify_txt_extension], ""]
-        }
-    }
+    extensions=[LinkifyExtension(linkify_callbacks=[dont_linkify_txt_extension])],
 )
 
 assert md.convert("not_link.txt"), '<p>not_link.txt</p>'
@@ -86,7 +81,7 @@ Pull requests are much welcome! :+1:
 
 _(more like a cheatsheet for me actually)_
 
-* Change version in `setup.py`,
-* Commit and tag it,
-* Push it (including tag),
-* Run `python setup.py register && python setup.py sdist upload`;
+- Change version in `setup.py`,
+- Commit and tag it,
+- Push it (including tag),
+- Run `python setup.py register && python setup.py sdist upload`;

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ def dont_linkify_net_extension(attrs, new=False):
     return attrs
 
 md = Markdown(
-    extensions=[LinkifyExtension(linkify_callbacks=[dont_linkify_txt_extension])],
+    extensions=[LinkifyExtension(linkify_callbacks=[dont_linkify_net_extension])],
 )
 
 assert md.convert("not_link.txt"), '<p>not_link.txt</p>'

--- a/mdx_linkify/mdx_linkify.py
+++ b/mdx_linkify/mdx_linkify.py
@@ -5,23 +5,31 @@ from markdown import Extension
 
 
 class LinkifyPostprocessor(Postprocessor):
-    def __init__(self, md, linkify_callbacks=[]):
+    def __init__(self, md, linkify_callbacks=[], linkify_parse_email=False):
         super(Postprocessor, self).__init__(md)
         self._callbacks = linkify_callbacks
+        self._parse_email = linkify_parse_email
 
     def run(self, text):
         text = bleach.linkify(text,
+                              parse_email=self._parse_email,
                               callbacks=self._callbacks,
                               skip_tags=['code'])
         return text
 
 
 class LinkifyExtension(Extension):
-    config = {'linkify_callbacks': [[], 'Callbacks to send to bleach.linkify']}
+    
+    def __init__(self, **kwargs):
+        self.config = {
+            'linkify_callbacks': [[], 'Callbacks to send to bleach.linkify'],
+            'linkify_parse_email': [False, 'Parse email addresses'],
+        }
+        super(LinkifyExtension, self).__init__(**kwargs)
 
     def extendMarkdown(self, md):
         md.postprocessors.register(
-            LinkifyPostprocessor(md, self.getConfig('linkify_callbacks')),
+            LinkifyPostprocessor(md, self.getConfig('linkify_callbacks'), self.getConfig('linkify_parse_email')),
             "linkify",
             50)
 

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(name="mdx_linkify",
           "Development Status :: 4 - Beta",
           "License :: OSI Approved :: MIT License",
       ],
-      install_requires=["Markdown>=3.0", "bleach>=2.0.0"],
+      install_requires=["Markdown>=3.0", "bleach>=3.1.0"],
       test_suite="mdx_linkify.tests")


### PR DESCRIPTION
I'd like to use this extension but it was missing two features:

- Linkify URLs with no schema (e.g. `example.com`), which seems to require a more recent version of bleach.
- Linkify email addresses, which is a bleach option.

This PR bumps bleach and adds the option to parse emails. I also needed to make some changes/fixes to get it to work :)